### PR TITLE
Fix Recursive Message Sending

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -215,7 +215,9 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
   @Override
   public boolean onShouldRetry(@NonNull Exception exception) {
     if (exception instanceof IOException)         return true;
-    if (exception instanceof RetryLaterException) return true;
+
+    // Loki - Disable since we have our own retrying
+    // if (exception instanceof RetryLaterException) return true;
     return false;
   }
 

--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -179,7 +179,8 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
 
   @Override
   public boolean onShouldRetry(@NonNull Exception exception) {
-    if (exception instanceof RetryLaterException) return true;
+    // Loki - Disable since we have our own retrying
+    // if (exception instanceof RetryLaterException) return true;
     return false;
   }
 

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -68,7 +68,7 @@ public abstract class PushSendJob extends SendJob {
                          .setQueue(destination.serialize())
                          .addConstraint(NetworkConstraint.KEY)
                          .setLifespan(TimeUnit.DAYS.toMillis(1))
-                         .setMaxAttempts(Parameters.UNLIMITED)
+                         .setMaxAttempts(3)
                          .build();
   }
 

--- a/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
@@ -134,7 +134,8 @@ public class PushTextSendJob extends PushSendJob implements InjectableType {
 
   @Override
   public boolean onShouldRetry(@NonNull Exception exception) {
-    if (exception instanceof RetryLaterException) return true;
+    // Loki - Disable since we have our own retrying
+    // if (exception instanceof RetryLaterException) return true;
 
     return false;
   }


### PR DESCRIPTION
This was because signal infinitely tries to send message on network errors. Since we already have retrying built into the loki api we just disable this behaviour and set a cap of 3 on PushSendJobs in case.

