### PR TITLE
fix: use the context compat register receiver to fix Android 14 crash

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -9,13 +9,14 @@ import android.os.Bundle;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
+import org.session.libsession.utilities.TextSecurePreferences;
 import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.home.HomeActivity;
 import org.thoughtcrime.securesms.onboarding.LandingActivity;
 import org.thoughtcrime.securesms.service.KeyCachingService;
-import org.session.libsession.utilities.TextSecurePreferences;
 
 import java.util.Locale;
 
@@ -168,7 +169,13 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
     };
 
     IntentFilter filter = new IntentFilter(KeyCachingService.CLEAR_KEY_EVENT);
-    registerReceiver(clearKeyReceiver, filter, KeyCachingService.KEY_PERMISSION, null);
+    ContextCompat.registerReceiver(
+            this,
+            clearKeyReceiver, filter,
+            KeyCachingService.KEY_PERMISSION,
+            null,
+            ContextCompat.RECEIVER_NOT_EXPORTED
+    );
   }
 
   private void removeClearKeyReceiver(Context context) {


### PR DESCRIPTION
Unsure if this is all of the required places, but seems to fix the startup crash and can't see any android studio warnings for other usages of `registerReceiver`